### PR TITLE
Update hfClient to v1 to include Namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,13 @@ module github.com/hobbyfarm/hfcli
 
 go 1.16
 
-replace (
-	github.com/hobbyfarm/gargantua => github.com/hobbyfarm/gargantua v0.2.2-0.20210823170529-e2466136c002
-	k8s.io/client-go => k8s.io/client-go v0.20.0
-)
+// github.com/hobbyfarm/gargantua => github.com/hobbyfarm/gargantua v0.2.2-0.20210823170529-e2466136c002
+replace k8s.io/client-go => k8s.io/client-go v0.20.0
 
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/ghodss/yaml v1.0.0
-	github.com/hobbyfarm/gargantua v0.2.0
+	github.com/hobbyfarm/gargantua v1.0.0
 	github.com/rancher/wrangler-cli v0.0.0-20210217230406-95cfa275f52f
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hobbyfarm/gargantua v0.2.2-0.20210823170529-e2466136c002 h1:i0sxD0unP5DQ0KL6hckBO4loTW8qwPHZD0tKKUzqYXI=
-github.com/hobbyfarm/gargantua v0.2.2-0.20210823170529-e2466136c002/go.mod h1:zcyT56Ifb6JweVRYxdykUIanIwBuSFq9vs+UHWoFc/4=
+github.com/hobbyfarm/gargantua v1.0.0 h1:xcFOx1OTvf91OV+fbGoBtr5uH52dGLr9QVFfZYgSTuY=
+github.com/hobbyfarm/gargantua v1.0.0/go.mod h1:zcyT56Ifb6JweVRYxdykUIanIwBuSFq9vs+UHWoFc/4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -55,5 +55,5 @@ func (sc *Scenario) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return scenario.Apply(s, HfClient)
+	return scenario.Apply(s, Namespace, HfClient)
 }

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -40,5 +40,5 @@ func NewDeleteScenario() *cobra.Command {
 
 func (sc *DeleteScenario) Run(cmd *cobra.Command, args []string) error {
 	logrus.Info(args[0])
-	return scenario.Delete(args[0], HfClient)
+	return scenario.Delete(args[0], Namespace, HfClient)
 }

--- a/pkg/cmd/get.go
+++ b/pkg/cmd/get.go
@@ -40,7 +40,7 @@ func NewGetScenario() *cobra.Command {
 
 func (sc *GetScenario) Run(cmd *cobra.Command, args []string) error {
 	logrus.Info(args[0], args[1])
-	s, err := scenario.Get(args[0], HfClient)
+	s, err := scenario.Get(args[0], Namespace, HfClient)
 
 	if err != nil {
 		return err

--- a/pkg/cmd/info.go
+++ b/pkg/cmd/info.go
@@ -43,7 +43,7 @@ func (ie *InfoEmail) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	return info.GetEmail(args[0], HfClient)
+	return info.GetEmail(args[0], Namespace, HfClient)
 }
 
 type InfoAccessCode struct {
@@ -64,5 +64,5 @@ func (iac *InfoAccessCode) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	return info.GetAccessCode(args[0], HfClient, iac.Stats)
+	return info.GetAccessCode(args[0], Namespace, HfClient, iac.Stats)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,7 +1,8 @@
 package cmd
 
 import (
-	hfClientSet "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned/typed/hobbyfarm.io/v1"
+	// hfClientSet "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned/typed/hobbyfarm.io/v1"
+	hfClientSet "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	command "github.com/rancher/wrangler-cli"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/clientcmd"
@@ -15,7 +16,7 @@ type Hfcli struct {
 
 var (
 	Namespace string
-	HfClient  *hfClientSet.HobbyfarmV1Client
+	HfClient  *hfClientSet.Clientset
 )
 
 func App() *cobra.Command {

--- a/pkg/scenario/apply.go
+++ b/pkg/scenario/apply.go
@@ -5,21 +5,21 @@ import (
 	"fmt"
 
 	hf "github.com/hobbyfarm/gargantua/pkg/apis/hobbyfarm.io/v1"
-	hfClientSet "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned/typed/hobbyfarm.io/v1"
+	hfClientSet "github.com/hobbyfarm/gargantua/pkg/client/clientset/versioned"
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Apply(s *hf.Scenario, hfc *hfClientSet.HobbyfarmV1Client) (err error) {
+func Apply(s *hf.Scenario, Namespace string, hfc *hfClientSet.Clientset) (err error) {
 
 	// check if scneario exists //
-	sGet, err := hfc.Scenarios().Get(context.TODO(), s.GetName(), v1.GetOptions{})
+	sGet, err := hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Get(context.TODO(), s.GetName(), v1.GetOptions{})
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logrus.Infof("creating scenario %s", s.GetName())
-			_, err = hfc.Scenarios().Create(context.TODO(), s, v1.CreateOptions{})
+			_, err = hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Create(context.TODO(), s, v1.CreateOptions{})
 			return err
 		} else {
 			return err
@@ -31,7 +31,7 @@ func Apply(s *hf.Scenario, hfc *hfClientSet.HobbyfarmV1Client) (err error) {
 		if ok && key == "hfcli" {
 			s.ObjectMeta.ResourceVersion = sGet.ObjectMeta.GetResourceVersion()
 			logrus.Infof("updating scenario %s", s.GetName())
-			_, err = hfc.Scenarios().Update(context.TODO(), s, v1.UpdateOptions{})
+			_, err = hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Update(context.TODO(), s, v1.UpdateOptions{})
 		} else {
 			err = fmt.Errorf("scenario %s already exists and is not managed by hfcli", sGet.GetName())
 		}
@@ -41,14 +41,14 @@ func Apply(s *hf.Scenario, hfc *hfClientSet.HobbyfarmV1Client) (err error) {
 	return err
 }
 
-func Get(name string, hfc *hfClientSet.HobbyfarmV1Client) (s *hf.Scenario, err error) {
+func Get(name string, Namespace string, hfc *hfClientSet.Clientset) (s *hf.Scenario, err error) {
 	logrus.Infof("downloading scenario %s", name)
 
-	return hfc.Scenarios().Get(context.TODO(), name, v1.GetOptions{})
+	return hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Get(context.TODO(), name, v1.GetOptions{})
 }
 
-func Delete(name string, hfc *hfClientSet.HobbyfarmV1Client) (err error) {
+func Delete(name string, Namespace string, hfc *hfClientSet.Clientset) (err error) {
 	logrus.Infof("deleting scenario %s", name)
 
-	return hfc.Scenarios().Delete(context.TODO(), name, v1.DeleteOptions{})
+	return hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Delete(context.TODO(), name, v1.DeleteOptions{})
 }

--- a/pkg/scenario/apply.go
+++ b/pkg/scenario/apply.go
@@ -14,12 +14,12 @@ import (
 func Apply(s *hf.Scenario, Namespace string, hfc *hfClientSet.Clientset) (err error) {
 
 	// check if scneario exists //
-	sGet, err := hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Get(context.TODO(), s.GetName(), v1.GetOptions{})
+	sGet, err := hfc.HobbyfarmV1().Scenarios(Namespace).Get(context.TODO(), s.GetName(), v1.GetOptions{})
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logrus.Infof("creating scenario %s", s.GetName())
-			_, err = hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Create(context.TODO(), s, v1.CreateOptions{})
+			_, err = hfc.HobbyfarmV1().Scenarios(Namespace).Create(context.TODO(), s, v1.CreateOptions{})
 			return err
 		} else {
 			return err
@@ -31,7 +31,7 @@ func Apply(s *hf.Scenario, Namespace string, hfc *hfClientSet.Clientset) (err er
 		if ok && key == "hfcli" {
 			s.ObjectMeta.ResourceVersion = sGet.ObjectMeta.GetResourceVersion()
 			logrus.Infof("updating scenario %s", s.GetName())
-			_, err = hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Update(context.TODO(), s, v1.UpdateOptions{})
+			_, err = hfc.HobbyfarmV1().Scenarios(Namespace).Update(context.TODO(), s, v1.UpdateOptions{})
 		} else {
 			err = fmt.Errorf("scenario %s already exists and is not managed by hfcli", sGet.GetName())
 		}
@@ -44,11 +44,11 @@ func Apply(s *hf.Scenario, Namespace string, hfc *hfClientSet.Clientset) (err er
 func Get(name string, Namespace string, hfc *hfClientSet.Clientset) (s *hf.Scenario, err error) {
 	logrus.Infof("downloading scenario %s", name)
 
-	return hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Get(context.TODO(), name, v1.GetOptions{})
+	return hfc.HobbyfarmV1().Scenarios(Namespace).Get(context.TODO(), name, v1.GetOptions{})
 }
 
 func Delete(name string, Namespace string, hfc *hfClientSet.Clientset) (err error) {
 	logrus.Infof("deleting scenario %s", name)
 
-	return hfc.HobbyfarmV1().Scenarios("Hobbyfarm123").Delete(context.TODO(), name, v1.DeleteOptions{})
+	return hfc.HobbyfarmV1().Scenarios(Namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 }


### PR DESCRIPTION
Currently, hfcli is not passing the namespace parameter to the underlying hobbyfarm api calls.
This PR updates the hobby farm client to v1 which enables namespace parameters to the underlying resource operations.
